### PR TITLE
Minor revisions to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-target/
-build/
+/target
+.DS_Store


### PR DESCRIPTION
- Removed unneeded entry for the 'build' directory.
- Scoped the entry for the 'target' directory to the project's root.
- Added an entry for .DS_Store, which is generated by Mac OS X's Finder app
  when browsing the project directory and should be ignored.
